### PR TITLE
Remove temp file after successful Store write and not only in case of…

### DIFF
--- a/ufs-server.js
+++ b/ufs-server.js
@@ -54,6 +54,7 @@ if (Meteor.isServer) {
                     fut.throw(err);
                 } else {
                     fut.return(file);
+                    fs.unlink(tmpFile);
                 }
             });
 


### PR DESCRIPTION
… an error.

I realised that the write method is not cleaning up the temp files after a successful write and only in the error branch. I added the `fs.unlink(tmpFile)` to make sure that files do not pile up in the temp directory. 