### PR TITLE
add additional storage drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ As the package is modular, you can add support for custom stores and even create
 
 * [UploadFS.store.Local](https://github.com/jalik/jalik-ufs-local)
 * [UploadFS.store.GridFS](https://github.com/jalik/jalik-ufs-gridfs)
+* [UploadFS.store.WABS](https://github.com/sebakerckhof/ufs-wabs)
+* [UploadFS.store.S3](https://github.com/sebakerckhof/ufs-s3)
 
 ## Introduction
 


### PR DESCRIPTION
I've made a storage adapter for s3 (amazon) and wabs (azure). 
Maybe you're interested to put add them in the readme, therefore this PR.
