### PR TITLE
This should do it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ PhotosStore = new UploadFS.store.Local({
 
 You can test the package by downloading and running [UFS-Example](https://github.com/jalik/ufs-example) which is simple demo of UploadFS.
 
+## Mobile Testing
+In order to test on mobile builds, `ROOT_URL` and `--mobile-server` must be set to your computer's local ip address and port:
+
+```bash
+export ROOT_URL=http://192.168.1.7:3000 && meteor run android-device --mobile-server=http://192.168.1.7:3000
+```
+
 ## Installation
 
 To install the package, execute this command in the root of your project :

--- a/package.js
+++ b/package.js
@@ -32,6 +32,5 @@ Package.onUse(function (api) {
 });
 
 Npm.depends({
-    mkdirp: '0.3.5',
-    os: '0.1.1'
+    mkdirp: '0.3.5'
 });

--- a/ufs-methods.js
+++ b/ufs-methods.js
@@ -2,7 +2,6 @@ const fs = Npm.require('fs');
 const http = Npm.require('http');
 const https = Npm.require('https');
 const Future = Npm.require('fibers/future');
-const os = Npm.require('os');
 
 Meteor.methods({
 
@@ -226,22 +225,5 @@ Meteor.methods({
         return store.getCollection().update(fileId, {
             $set: {uploading: false}
         });
-    },
-    ufsGetUrl: function (storesPath, name, https) {
-        // get server ip
-        let path = `${storesPath}/${name}`;
-        let url = Meteor.absoluteUrl(path, {
-            secure: https
-        });
-        let urlreg = url.match(/^(http|http):\/\/[^:\/]+(?::(\d+))?/);
-        let protocol = urlreg[1];
-        let port = urlreg[2];
-        let ip = os.networkInterfaces().en0.filter((iface)=> {
-            if (iface.address.split('.').length === 4) {
-                return true;
-            }
-        })[0].address;
-        return `${protocol}://${ip}:${port}/${path}`;
-
     }
 });

--- a/ufs-server.js
+++ b/ufs-server.js
@@ -51,7 +51,36 @@ WebApp.connectHandlers.use((req, res, next) => {
     let parsedUrl = URL.parse(req.url);
     let path = parsedUrl.pathname.substr(UploadFS.config.storesPath.length + 1);
 
-    if (req.method === 'POST') {
+    let setCors = ()=> {
+        res.setHeader('Access-Control-Allow-Origin', req.headers.origin);
+        res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    }
+
+    if (req.method === "OPTIONS") {
+        let regExp = new RegExp('^\/([^\/\?]+)\/([^\/\?]+)$');
+        let match = regExp.exec(path);
+
+        // Request is not valid
+        if (match === null) {
+            res.writeHead(400);
+            res.end();
+            return;
+        }
+
+        // Get store
+        let store = UploadFS.getStore(match[1]);
+        if (!store) {
+            res.writeHead(404);
+            res.end();
+            return;
+        }
+
+        // If a store is found, go ahead and allow the origin
+        setCors();
+
+        next();
+    }
+    else if (req.method === 'POST') {
         // Get store
         let regExp = new RegExp('^\/([^\/\?]+)\/([^\/\?]+)$');
         let match = regExp.exec(path);
@@ -71,7 +100,7 @@ WebApp.connectHandlers.use((req, res, next) => {
             return;
         }
         // If a store is found, go ahead and allow the origin
-        res.setHeader("Access-Control-Allow-Origin", req.headers.origin);
+        setCors();
 
         // Get file
         let fileId = match[2];

--- a/ufs-store.js
+++ b/ufs-store.js
@@ -395,8 +395,9 @@ UploadFS.Store.prototype.getFileURL = function (fileId) {
  * Returns the store URL
  */
 UploadFS.Store.prototype.getURL = function () {
-    // call a server method to get server ip
-    return Meteor.call('ufsGetUrl', UploadFS.config.storesPath, this.getName(), UploadFS.config.https);
+    return Meteor.absoluteUrl(`${UploadFS.config.storesPath}/${this.getName()}`, {
+        secure: UploadFS.config.https
+    });
 };
 
 /**

--- a/ufs.js
+++ b/ufs.js
@@ -61,14 +61,14 @@ if (Meteor.isClient) {
      * @param callback
      */
     UploadFS.selectFile = (callback) => {
-        let img = document.createElement('input');
-        img.type = 'file';
-        img.multiple = false;
-        img.onchange = (ev) => {
+        this.img = document.createElement('input');
+        this.img.type = 'file';
+        this.img.multiple = false;
+        this.img.onchange = (ev) => {
             let files = ev.target.files;
             callback.call(UploadFS, files[0]);
         };
-        img.click();
+        this.img.click();
     };
 
     /**
@@ -76,16 +76,16 @@ if (Meteor.isClient) {
      * @param callback
      */
     UploadFS.selectFiles = (callback) => {
-        let img = document.createElement('input');
-        img.type = 'file';
-        img.multiple = true;
-        img.onchange = (ev) => {
+        this.img = document.createElement('input');
+        this.img.type = 'file';
+        this.img.multiple = true;
+        this.img.onchange = (ev) => {
             let files = ev.target.files;
 
             for (let i = 0; i < files.length; i += 1) {
                 callback.call(UploadFS, files[i]);
             }
         };
-        img.click();
+        this.img.click();
     };
 }


### PR DESCRIPTION
@jalik
Try this out! I believe the issue with the onchanged event not being called was due to premature garbage collection? Not entirely sure but attaching img to window solves and I get uploads on the first try consistently. Maybe you have a better solution in mind? Either way, like I said in #58 I reverted package.js, ufs-methods, and ufs-stores. To their initial state. ufs-server still needs the Access-Control-Allow-Origin header to be set in order for mobile apps to successfully upload images. 

One other thing to note, support for multi file upload on android webviews is spotty at best. I have been unsuccessful in getting multifile select to work on builds on my device. I'm curious if you're having the same experience with selectFiles.

Let me know what you think.
Thanks!